### PR TITLE
Set tabIndex to -1 on IconButton to skip tabbing to visibility button

### DIFF
--- a/src/PasswordField.js
+++ b/src/PasswordField.js
@@ -142,6 +142,7 @@ class PasswordField extends React.Component {
           iconStyle={styles.visibilityIcon}
           style={styles.visibilityButton}
           disabled={disableButton || other.disabled}
+          tabIndex={-1}
         >
           {visible ? <Visibility /> : <VisibilityOff />}
         </IconButton>


### PR DESCRIPTION
After typing a password I think most people would expect tab to jump to the next field instead of the visibility button. 