### PR TITLE
Fix broken tab index for IE

### DIFF
--- a/src/PasswordField.js
+++ b/src/PasswordField.js
@@ -143,7 +143,7 @@ class PasswordField extends React.Component {
           iconStyle={styles.visibilityIcon}
           style={styles.visibilityButton}
           disabled={disableButton || other.disabled}
-          tabIndex={-1}
+          tabIndex={0}
         >
           {visible ? <Visibility /> : <VisibilityOff />}
         </IconButton>


### PR DESCRIPTION
`-1` causes the focus to act strangely (going back to body). `0` will do what is intended.