### PR TITLE
Removed legacy lifecicle method | componentWillReceiveProps

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-2017 Team Wertarbyte
+Copyright (c) 2016-2020 Team Wertarbyte
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/PasswordField.js
+++ b/src/PasswordField.js
@@ -23,11 +23,13 @@ class PasswordField extends React.Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
-    if (nextProps.visible !== this.props.visible) {
-      this.setState({
-        visible: nextProps.visible
-      })
+  static getDerivedStateFromProps(nextProps, prevState){
+    return nextProps.visible !== prevState.visible ? { visible: nextProps.visible } : null 
+  }
+
+  componentDidUpdate(prevProps) {
+    if(prevProps.visible !== this.props.visible) {
+      this.setState({visible: this.props.visible})
     }
   }
 

--- a/src/PasswordField.js
+++ b/src/PasswordField.js
@@ -23,14 +23,8 @@ class PasswordField extends React.Component {
     }
   }
 
-  static getDerivedStateFromProps(nextProps, prevState){
-    return nextProps.visible !== prevState.visible ? { visible: nextProps.visible } : null 
-  }
-
-  componentDidUpdate(prevProps) {
-    if(prevProps.visible !== this.props.visible) {
-      this.setState({visible: this.props.visible})
-    }
+  static getDerivedStateFromProps (nextProps, prevState) {
+    return nextProps.visible !== prevState.visible ? { visible: nextProps.visible } : null
   }
 
   /**

--- a/src/PasswordField.spec.js
+++ b/src/PasswordField.spec.js
@@ -26,6 +26,15 @@ describe('<PasswordField />', () => {
     expect(tree.find('input').prop('type')).toBe('text')
   })
 
+  it('shows and hides the password when changing the visible prop', () => {
+    const tree = mount(<PasswordField />)
+    expect(tree.find('input').prop('type')).toBe('password')
+    tree.setProps({ visible: true })
+    expect(tree.find('input').prop('type')).toBe('text')
+    tree.setProps({ visible: false })
+    expect(tree.find('input').prop('type')).toBe('password')
+  })
+
   it('toggles the visibility when clicking the button', () => {
     const tree = mount(<PasswordField />)
 


### PR DESCRIPTION
Removed deprecated method componenWillReceiveProps to Add getDerivedStateFromProps and componentDidUpdate methods.

**This new method is equivalent to old method, solved only React warnings in up to date versions (^16.3.0).**

Fixes #27 